### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/pages/api/user-search.js
+++ b/pages/api/user-search.js
@@ -2,7 +2,7 @@
 // DO NOT USE IN PRODUCTION
 // This API endpoint demonstrates a command injection vulnerability for CodeQL detection
 
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 
 export default function handler(req, res) {
   const { username } = req.query;
@@ -11,11 +11,10 @@ export default function handler(req, res) {
     return res.status(400).json({ error: 'Username is required' });
   }
 
-  // VULNERABILITY: User input is directly concatenated into a shell command
-  // An attacker could inject malicious commands using input like: "user; rm -rf /"
-  const command = `grep ${username} /var/log/users.log`;
-  
-  exec(command, (error, stdout, stderr) => {
+  // SAFER: Use execFile with arguments array to avoid shell command injection
+  const args = [username, '/var/log/users.log'];
+
+  execFile('grep', args, (error, stdout, stderr) => {
     if (error) {
       return res.status(500).json({ error: error.message });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/github-samples/gitfolio/security/code-scanning/1](https://github.com/github-samples/gitfolio/security/code-scanning/1)

In general, the problem should be fixed by avoiding shell command construction with string concatenation and `exec`. Instead, either (a) use a safer API like `execFile` (or `spawn`) that does not invoke a shell and accepts arguments as an array, or (b) avoid calling the shell at all and implement the functionality directly in JavaScript. If shell execution is unavoidable, validate and constrain user input strictly before use.

The best, minimal-impact fix here is to replace `exec` with `execFile`, and pass `username` as a separate argument to `grep` in an array. This preserves the existing functionality (searching for the username in `/var/log/users.log`) while preventing shell metacharacters in `username` from being interpreted by a shell. We should also ensure the `grep` binary is invoked directly, not via a shell. Concretely:
- Change the import to bring in `execFile` instead of `exec`.
- Remove the concatenated `command` string.
- Call `execFile('grep', [username, '/var/log/users.log'], callback)`.

All changes are confined to `pages/api/user-search.js`, in the code shown.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
