### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/pages/api/download.js
+++ b/pages/api/download.js
@@ -12,14 +12,17 @@ export default function handler(req, res) {
     return res.status(400).json({ error: 'Filename is required' });
   }
 
-  // VULNERABILITY: Path Traversal
-  // User input is used directly to construct file paths
-  // An attacker could use input like: "../../../../etc/passwd"
-  const filePath = path.join(process.cwd(), 'uploads', filename);
-  
+  // Securely construct a path under the uploads directory
+  const uploadsRoot = path.join(process.cwd(), 'uploads');
+  const resolvedPath = path.resolve(uploadsRoot, String(filename));
+
+  // Ensure the resolved path is within the uploads root to prevent path traversal
+  if (!resolvedPath.startsWith(uploadsRoot + path.sep) && resolvedPath !== uploadsRoot) {
+    return res.status(400).json({ error: 'Invalid filename' });
+  }
+
   try {
-    // Reading file without proper validation
-    const fileContent = fs.readFileSync(filePath, 'utf8');
+    const fileContent = fs.readFileSync(resolvedPath, 'utf8');
     
     res.status(200).json({ 
       filename: filename,


### PR DESCRIPTION
Potential fix for [https://github.com/github-samples/gitfolio/security/code-scanning/3](https://github.com/github-samples/gitfolio/security/code-scanning/3)

In general, the correct fix is to ensure that any path derived from user input is safely constrained to a known root directory. You should normalize the path (using `path.resolve`) to eliminate `..` segments, optionally resolve symlinks (with `fs.realpathSync` or `fs.realpath`), and then verify that the resulting absolute path is still inside the intended root directory. If it is not, you must reject the request.

For this specific endpoint, the safest fix that preserves existing functionality is:

1. Define a constant root directory for uploaded files, e.g. `const UPLOADS_ROOT = path.join(process.cwd(), 'uploads');`.
2. Build an absolute path from this root and the user-provided `filename` using `path.resolve(UPLOADS_ROOT, filename)`. This normalizes the path and collapses `..` segments.
3. Optionally call `fs.realpathSync` on the resolved path to handle symlinks.
4. Check that the final `filePath` starts with `UPLOADS_ROOT + path.sep` (or equals `UPLOADS_ROOT` if you allow the root itself). If it does not, respond with HTTP 400 or 403 instead of reading the file.
5. Use this validated `filePath` in `fs.readFileSync`.

We can make these changes entirely inside `pages/api/download.js`, just above and around the current `filePath` construction and `fs.readFileSync` call. No new imports are required, since `fs` and `path` are already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
