### PR TITLE
Potential fix for code scanning alert no. 2: Reflected cross-site scripting

### DIFF
--- a/pages/api/display-message.js
+++ b/pages/api/display-message.js
@@ -2,6 +2,15 @@
 // DO NOT USE IN PRODUCTION
 // This API endpoint demonstrates XSS vulnerabilities for CodeQL detection
 
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export default function handler(req, res) {
   const { message } = req.query;
   
@@ -20,7 +29,7 @@ export default function handler(req, res) {
       </head>
       <body>
         <h1>Your Message:</h1>
-        <div>${message}</div>
+        <div>${escapeHtml(message)}</div>
       </body>
     </html>
   `;


### PR DESCRIPTION
Potential fix for [https://github.com/github-samples/gitfolio/security/code-scanning/2](https://github.com/github-samples/gitfolio/security/code-scanning/2)

In general, to fix reflected XSS you must ensure any user-controlled data is contextually encoded before being inserted into an HTML response. For HTML body content (text between tags), HTML-escape characters like `<`, `>`, `&`, `"`, and `'` so they are rendered as text instead of being interpreted as markup or script.

The best fix here, without changing existing functionality, is to HTML-escape `message` before interpolating it into the template. We can introduce a small helper function (in the same file) that replaces the dangerous characters with their HTML entity equivalents, then use that function when building `html`. This preserves the same API and behavior for normal input, but ensures that any HTML special characters in `message` are rendered safely. Concretely:
- Add a local `escapeHtml` function near the top of `pages/api/display-message.js`.
- Change `<div>${message}</div>` to `<div>${escapeHtml(message)}</div>`.
No new external dependencies are strictly required; we can implement a minimal, well-known HTML escaping routine inline.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
