### PR TITLE
Actions start

### DIFF
--- a/.github/workflows/label-new-issue.yml
+++ b/.github/workflows/label-new-issue.yml
@@ -1,0 +1,20 @@
+name: Label New Issues
+
+on:
+  issues:
+    types: [opened]
+    
+jobs:
+  label-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      
+    steps:
+      - name: Add triage label
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            ISSUE_NUMBER: ${{ github.event.issue.number }}
+            LABEL: "triage"
+        run: gh issue edit "$ISSUE_NUMBER" --add-label "$LABEL"
+                                        


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automatically label newly opened issues for triage. This helps streamline the issue management process by ensuring all new issues are consistently tagged for review.

Workflow automation:

* Added a `.github/workflows/label-new-issue.yml` workflow that triggers on new issue creation and applies a "triage" label to the issue using the GitHub CLI.