### PR TITLE
Add new labeler workflow

### DIFF
--- a/.github/workflows/label-new-issue.yml
+++ b/.github/workflows/label-new-issue.yml
@@ -1,0 +1,23 @@
+name: Label New Issues
+
+on:
+  issues:
+    types: [opened]
+    
+jobs:
+  label-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Add triage label
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            ISSUE_NUMBER: ${{ github.event.issue.number }}
+            LABEL: "triage"
+        run: gh issue edit "$ISSUE_NUMBER" --add-label "$LABEL"
+                                                      


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically label newly opened issues for easier triage and management.

Automation for issue triage:

* Added `.github/workflows/label-new-issue.yml` to automatically apply the "triage" label to any newly opened issue using GitHub Actions and the `gh` CLI.