### PR TITLE
Update copyright holder in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 GitHub Samples
+Copyright GitHub, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the copyright information in the `LICENSE` file to reflect the correct copyright holder.

* Changed the copyright notice from "GitHub Samples" to "GitHub, Inc." in the `LICENSE` file.