### PR TITLE
docs: clarify location for improving section copy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Open [http://localhost:3000](http://localhost:3000) to see your portfolio.
 
 All your content lives in **one file**: `app/page.tsx`
 
+**Beginner Tip:** A quick way to start contributing is to improve button text or section copy in `app/page.tsx`. This helps you understand the code structure while making meaningful improvements.
+
 ### 1. Update Your Name/Brand
 Find the navigation section and change `GITFOLIO` to your name:
 ```tsx


### PR DESCRIPTION
## Summary
This PR adds a beginner tip to the README that specifies the exact file location where beginners can start improving button text or section copy.

## Changes
Added a clear suggestion in the README to help new contributors know exactly where to start:

**Before:** The README did not specify where to improve button text or section copy.

**After:** The README now includes a beginner tip: "A quick way to start contributing is to improve button text or section copy in `app/page.tsx`"

## Testing
- Verified the README rendering
- Confirmed the tip appears in the correct location (after the main file reference)

## Related Issue
Resolves #68

## Screenshot
The tip now appears in the "Customize Your Portfolio" section, right after the "All your content lives in **one file**: `app/page.tsx`" statement.